### PR TITLE
Prevent zoom on iOS

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="initial-scale=1, width=device-width, user-scalable=no" />
     <link rel="icon" href="/favicon.ico" />
     <meta name="theme-color" content="#ffffff" />
     <meta name="description" content="kompass travel planner" />

--- a/app/public/manifest.json
+++ b/app/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "TanStack App",
-  "name": "Create TanStack App Sample",
+  "short_name": "kompass",
+  "name": "kompass",
   "icons": [
     {
       "src": "favicon.ico",
@@ -21,5 +21,6 @@
   "start_url": ".",
   "display": "standalone",
   "theme_color": "#000000",
-  "background_color": "#ffffff"
+  "background_color": "#ffffff",
+  "orientation": "portrait"
 }


### PR DESCRIPTION
## Summary
- Add `user-scalable=no` to viewport meta tag to prevent zoom on iOS
- Update PWA manifest with kompass branding and portrait orientation

## Changes
- `index.html`: Updated viewport meta with `user-scalable=no`
- `public/manifest.json`: Changed app name from "TanStack App" to "kompass", added `orientation: "portrait"`

## Testing
Tested on iOS Safari - zoom prevention works using same technique as tilly project.