### PR TITLE
use temp dir for OPTD CSV downloads

### DIFF
--- a/transportation-api/internal/app/app.go
+++ b/transportation-api/internal/app/app.go
@@ -26,7 +26,7 @@ func Run(cfg *config.Config) {
 	log := logger.New(cfg.Log.Level)
 
 	// Use-Case
-	useCases := createUseCases(cfg)
+	useCases := createUseCases(cfg, log)
 
 	// HTTP Server
 	httpServer := httpserver.New(
@@ -55,9 +55,12 @@ func Run(cfg *config.Config) {
 	}
 }
 
-func createUseCases(cfg *config.Config) usecase.UseCases {
+func createUseCases(cfg *config.Config, log *logger.Logger) usecase.UseCases {
 	ors := openrouteservice.New(cfg.WebApi)
-	optd := opentraveldata.New(cfg.WebApi)
+	optd, err := opentraveldata.New(cfg.WebApi)
+	if err != nil {
+		log.Fatal(fmt.Errorf("app - createUseCases - opentraveldata.New: %w", err))
+	}
 
 	flightsUseCase := flights.New(amadeus.New(cfg.WebApi, optd))
 	trainsUseCase := trains.New(dbvendo.New(cfg.WebApi))

--- a/transportation-api/internal/repo/opentraveldata/opentraveldata.go
+++ b/transportation-api/internal/repo/opentraveldata/opentraveldata.go
@@ -24,12 +24,15 @@ type OpenTravelData struct {
 	dataDir string
 }
 
-func New(config config.WebApi) *OpenTravelData {
-	dataDir, _ := os.MkdirTemp("", "optd-")
+func New(config config.WebApi) (*OpenTravelData, error) {
+	dataDir, err := os.MkdirTemp("", "optd-")
+	if err != nil {
+		return nil, fmt.Errorf("create temp dir: %w", err)
+	}
 	return &OpenTravelData{
 		baseURL: config.OpenTravelDataBaseURL,
 		dataDir: dataDir,
-	}
+	}, nil
 }
 
 func (a *OpenTravelData) LookupAirport(iata string) (entity.AirportWithTimezone, error) {


### PR DESCRIPTION
## Summary
- OPTD CSV files now download to temp dir created via `os.MkdirTemp("", "optd-")`
- Enables read-only filesystem deployment

## Changes
- Added `dataDir` field to `OpenTravelData` struct
- Modified `New()` to create temp dir on init
- Updated `accessDataset()` and `downloadDataset()` to use temp dir paths

## Test plan
- [ ] Verify OPTD lookups work (airports, airlines, aircraft)
- [ ] Confirm CSVs download to temp dir on first access
- [ ] Test deployment on read-only filesystem